### PR TITLE
Sandbox/liability machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,121 +1,102 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+## Project
 
-## What this project is
+PZTools — desktop viewer/editor for Project Zomboid `Distributions.lua` and `ProceduralDistributions.lua`. Parses Lua into domain model, displays in Avalonia UI with filtering, tabbed editing, undo/redo, save to disk.
 
-PZTools is a desktop tool for viewing and editing Project Zomboid loot distribution files (`Distributions.lua` and `ProceduralDistributions.lua`). The user points it at a game or mod folder, the tool parses the Lua files into a domain model, and displays them in an Avalonia UI with filtering, selection, and undo/redo editing.
-
-## Build and run
+## Build
 
 ```bash
-# Build the whole solution
-dotnet build PZTools.sln
-
-# Run the UI
-dotnet run --project UI/UI.csproj
-
-# Build parsing library only
-dotnet build DataInput/DataInput.csproj
+dotnet build PZTools.sln        # full solution
+dotnet run --project UI/UI.csproj  # run UI
+dotnet build DataInput/DataInput.csproj  # parsing lib only
 ```
 
-Target framework is **net10.0**. There are no automated tests in the solution.
+Target: **net10.0**. No automated tests.
 
-## Solution structure
+## Structure
 
-| Project | Role |
-|---|---|
-| `DataInput` | Parsing library — Lua loading, domain model, validation, serialization, comment preservation. No UI dependencies. |
-| `UI` | Active Avalonia frontend. References `DataInput`. |
+- `DataInput` — parsing, domain model, validation, serialization, comments. No UI deps.
+- `UI` — Avalonia frontend, references DataInput.
 
-**Only `DataInput` and `UI` are under active development.** Legacy projects (`OldUI`, `Data`, `PZEditAvaloniaUI`) have been removed.
+Only these two are active. Legacy projects removed.
 
-## DataInput architecture
+## Git rules
 
-Parsing follows a strict layered pipeline with no backwards references:
+- ONLY branch: `sandbox/liability-machine`. Never commit/push elsewhere. Never ask to.
+- User cherry-picks accepted work to correct branches.
+- Commit + push frequently. Small focused commits per logical change.
 
-```
-ILuaLoader (LuaFileLoader)
-    ↓  raw NLua LuaTable
-DistributionMapper
-    ↓  domain objects
-IValidator[] (DistributionValidator, ProceduralReferenceValidator)
-    ↓  ParseError list
-DistributionParser  ← thin orchestrator, inject via CreateDefault() or ctor
-    ↓
-ParseResult { IReadOnlyList<Distribution>, IReadOnlyList<ParseError> }
-```
+## DataInput
 
-**Domain model hierarchy:**
-- `Distribution : ItemParent` — top-level entry (room, bag, cache, profession, or procedural)
-- `Container : ItemParent` — shelf/counter nested inside a Distribution; also used for `bags` entries
-- `Item` — value struct (`Name`, `Chance`); stored in `List<Item>` on `ItemParent`
-- `ProcListEntry` — references a procedural `Distribution` by name and carries resolved pointer
-
-`DistributionClassifier` maps distribution names to `DistributionType` (Room/Bag/Cache/Profession/Procedural) via static `HashSet` lookups.
-
-`NamePool` interns strings so identical item names share one heap instance across all distributions.
-
-Error handling is non-fatal by default: field parse failures log a `ParseError` and continue. Fatal errors (file not found, table not found) cause early return from `DistributionParser.Parse`.
-
-### Serialization
-
-`LuaWriter` serializes domain objects back to Lua source text. Key constraints driven by the game's `ItemPickerJava`:
-- Non-procedural containers **must** always have both `rolls` and `items` keys (even when 0 / empty).
-- Junk blocks **must** always have `rolls` (Java casts unconditionally, no null check).
-- Distribution-level `rolls` and `items` are emitted together (if rolls exists, items must too).
-- Procedural containers emit an empty `procList = {}` when they have no entries.
-
-### Comment preservation
-
-`LuaCommentExtractor` is a line-by-line state machine (Preamble → InTable → Postamble) that extracts comments keyed by structural path. `CommentMap` stores these and blank-line metadata. The Postamble captures everything after the main table close verbatim (utility functions, event registrations, `mergeDistributions` calls) and writes it back via `EmitVerbatim`.
-
-### Reference tracking
-
-Lua files use cross-table references (e.g. `bags = BagsAndContainers.SomeBag`, `items = BagsAndContainers.BanditItems`, `junk = ClutterTables.DeskJunk`). These are tracked via `LuaRefInfo` and stored on domain objects:
-- `Container.SourceReference` / `SourceReferenceFile` — whole container is a reference
-- `ItemParent.ItemsReference` — items list is a reference
-- `ItemParent.JunkReference` / `JunkReferenceFile` — junk block is a reference
-- `ItemParent.JunkItemsReference` — items inside junk is a reference
-- `ItemParent.BagsReference` / `BagsFileReference` — bags block is a reference
-
-## UI architecture
-
-**Pattern:** Plain Avalonia code-behind — no ReactiveUI, no ViewModels. State lives in `MainWindow` and the controls themselves.
+### Parse pipeline (no backwards refs)
 
 ```
-MainWindow (code-behind, owns TabControl + per-tab UndoRedoStack)
-├── DistributionListControl  — left panel; filter pills + text search, fires OpenRequested event
-├── TabControl (TabBar)      — center panel; each tab wraps a DistributionDetailControl
-│   └── DistributionDetailControl — Load(Distribution, UndoRedoStack) / ShowEmpty()
-│       └── ContainerControl (one per container, built dynamically)
-│           └── ItemListControl, ProcListListControl
-├── ErrorListControl          — bottom panel
-└── Right panel               — Properties: shows read-only detail when clicking proc reference links
+ILuaLoader → raw LuaTable → DistributionMapper → domain objects
+→ IValidator[] → ParseError list → DistributionParser → ParseResult
 ```
 
-### Tabbed detail view
+### Domain model
 
-Distributions open in tabs (double-click or context menu). Each tab has its own `TabState`:
-- Independent `UndoRedoStack` (undo/redo is per-tab)
-- Dirty indicator dot on tab header
-- Close button with save confirmation for dirty tabs
-- Pin support (pinned tabs resist close operations)
-- LRU eviction: max 10 cached tab controls; older tabs dispose their UI and recreate from the `Distribution` model on reactivation
+- `Distribution : ItemParent` — top-level (room/bag/cache/profession/procedural)
+- `Container : ItemParent` — nested shelf/counter; also `bags` entries
+- `Item` — struct (Name, Chance) in `List<Item>` on ItemParent
+- `ProcListEntry` — ref to procedural Distribution by name + resolved pointer
+- `DistributionClassifier` — name → DistributionType via HashSet lookups
+- `NamePool` — string interning across distributions
 
-Tab context menu: Close / Close All / Close Others / Close Left / Close Right / Pin.
+Errors: non-fatal by default (log ParseError, continue). Fatal = early return.
 
-`MainWindow` handles the folder picker (`StorageProvider`), keyboard shortcuts (Ctrl+Z/Y/Shift+Z/W), and panel show/hide toggling (saves/restores `GridLength` on each column/row).
+### Serialization (`LuaWriter`)
 
-**Undo/redo:** `UndoRedoStack` owns two stacks of `IUndoableAction`. Controls receive the stack via their `Load(...)` method and push `PropertyChangeAction<T>` when editable fields change.
+ItemPickerJava constraints:
+- Non-procedural containers: always emit both `rolls` + `items`
+- Junk blocks: always emit `rolls`
+- Distribution-level: `rolls` + `items` emitted together
+- Procedural without entries: emit `procList = {}`
 
-**Note:** `MainWindow.axaml` uses `x:CompileBindings="False"` — bindings there are runtime, not compile-time. Controls may differ; check per-file.
+### Comments (`LuaCommentExtractor`)
 
-## Key conventions
+State machine: Preamble → InTable → Postamble. Comments keyed by structural path. Postamble captures everything after main table close verbatim (utility funcs, event registrations, `mergeDistributions`).
 
-- `ILuaLoader` is the injection seam for `DistributionParser` — pass a stub to avoid file I/O in tests.
-- `ParseResult` is always returned (never throws); callers check `HasFatalErrors`.
-- `Item` is a struct to keep `List<Item>` allocation-friendly.
-- Lua item lists arrive as flat alternating `name, chance, name, chance` sequences — see `MapItemChances` in `DistributionMapper`.
-- The Lua files are loaded from fixed relative paths under the game folder: `media/lua/server/Items/ProceduralDistributions.lua` and `Distributions.lua`.
-- Container properties `OnlyOne`, `MaxMap`, `StashChance` are used by BagsAndContainers entries.
+### References (`LuaRefInfo`)
+
+Cross-table refs (e.g. `bags = BagsAndContainers.X`, `junk = ClutterTables.Y`):
+- `Container.SourceReference/SourceReferenceFile` — whole container
+- `ItemParent.ItemsReference` — items list
+- `ItemParent.JunkReference/JunkReferenceFile` — junk block
+- `ItemParent.JunkItemsReference` — items inside junk
+- `ItemParent.BagsReference/BagsFileReference` — bags block
+
+## UI
+
+Plain code-behind, no MVVM. State in MainWindow + controls.
+
+```
+MainWindow (TabControl + per-tab UndoRedoStack)
+├── DistributionListControl — left; filters + search, fires OpenRequested
+├── TabControl → DistributionDetailControl → ContainerControl → ItemListControl, ProcListListControl
+├── ErrorListControl — bottom
+└── Properties panel — right; read-only detail for proc ref links
+```
+
+### Tabs
+
+Per-tab `TabState`: independent UndoRedoStack, dirty dot, close w/ save confirm, pin support. LRU eviction at 10 cached controls. Context menu: Close/All/Others/Left/Right/Pin.
+
+### Undo/redo
+
+`UndoRedoStack` with `IUndoableAction`. Controls get stack via `Load()`, push `PropertyChangeAction<T>`. Shortcuts: Ctrl+Z/Y/Shift+Z/W.
+
+### Bindings
+
+`MainWindow.axaml`: `x:CompileBindings="False"` (runtime). Other controls may differ — check per-file.
+
+## Conventions
+
+- `ILuaLoader` = injection seam for tests (stub to avoid file I/O)
+- `ParseResult` never throws; check `HasFatalErrors`
+- `Item` is struct for allocation-friendly lists
+- Lua items = flat alternating `name, chance, name, chance` — see `MapItemChances`
+- Lua paths: `media/lua/server/Items/ProceduralDistributions.lua` and `Distributions.lua`
+- Container props `OnlyOne`, `MaxMap`, `StashChance` used by BagsAndContainers

--- a/UI/App.axaml
+++ b/UI/App.axaml
@@ -32,8 +32,8 @@
                 <Setter Property="AllowAutoHide" Value="False" />
             </Style>
             <Style Selector="ScrollBar">
-                <Setter Property="Width" Value="6" />
-                <Setter Property="MinWidth" Value="6" />
+                <Setter Property="Width" Value="14" />
+                <Setter Property="MinWidth" Value="14" />
                 <Setter Property="Background" Value="Transparent" />
                 <Setter Property="Opacity" Value="0.6" />
             </Style>

--- a/UI/Controls/DistributionListControl.axaml
+++ b/UI/Controls/DistributionListControl.axaml
@@ -102,7 +102,7 @@
                   SelectionChanged="DistTree_SelectionChanged">
             <TreeView.ItemTemplate>
                 <TreeDataTemplate ItemsSource="{Binding Children}">
-                    <Grid ColumnDefinitions="Auto,*,Auto" MinHeight="22">
+                    <Grid ColumnDefinitions="Auto,*,Auto" MinHeight="22" Margin="0,0,6,0">
                         <!-- Folder icon (visible only for folders) -->
                         <TextBlock Grid.Column="0"
                                    Text="&#x1F4C1; "

--- a/UI/Controls/DistributionListControl.axaml.cs
+++ b/UI/Controls/DistributionListControl.axaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
@@ -348,6 +349,7 @@ public partial class DistributionListControl : UserControl
 
     private void OnTreePointerPressed(object? sender, PointerPressedEventArgs e)
     {
+        if (e.Source is Visual v && v.FindAncestorOfType<ScrollBar>() is not null) return;
         if (!e.GetCurrentPoint(DistTree).Properties.IsLeftButtonPressed) return;
         _dragStartPoint = e.GetPosition(DistTree);
 
@@ -372,6 +374,7 @@ public partial class DistributionListControl : UserControl
 
     private async void OnTreePointerMoved(object? sender, PointerEventArgs e)
     {
+        if (e.Source is Visual v && v.FindAncestorOfType<ScrollBar>() is not null) return;
         if (!_dragStartPending) return;
 
         var pos = e.GetPosition(DistTree);

--- a/UI/Controls/DistributionListControl.axaml.cs
+++ b/UI/Controls/DistributionListControl.axaml.cs
@@ -848,6 +848,7 @@ public partial class DistributionListControl : UserControl
 
     private void MoveToFolder_Click(object? sender, RoutedEventArgs e)
     {
+        e.Handled = true; // Stop bubbling to parent menu items
         if (sender is not MenuItem menuItem) return;
         var folderPath = menuItem.Tag as string;
         if (folderPath is null) return;

--- a/UI/Controls/DistributionListControl.axaml.cs
+++ b/UI/Controls/DistributionListControl.axaml.cs
@@ -456,7 +456,7 @@ public partial class DistributionListControl : UserControl
         foreach (var node in draggedNodes)
         {
             if (node.IsFolder)
-                MoveFolderTo(node.Name, dropFolder);
+                MoveFolderTo(node, dropFolder);
             else if (node.Distribution is not null)
                 MoveDistributionTo(node.Distribution.Name, dropFolder);
         }
@@ -527,14 +527,14 @@ public partial class DistributionListControl : UserControl
         if (targetFolderNode is null) return; // move to root = just remove from folders
 
         // Find the target FolderDefinition and add
-        var (targetDef, _) = FindFolderDefinition(targetFolderNode.Name);
+        var (targetDef, _) = FindFolderDefinition(targetFolderNode);
         targetDef?.DistributionNames.Add(distName);
     }
 
-    private void MoveFolderTo(string folderName, ExplorerNode? targetFolderNode)
+    private void MoveFolderTo(ExplorerNode folderNode, ExplorerNode? targetFolderNode)
     {
         // Find and remove the folder from its current location
-        var (folderDef, oldParentList) = FindFolderDefinition(folderName);
+        var (folderDef, oldParentList) = FindFolderDefinition(folderNode);
         if (folderDef is null) return;
         oldParentList.Remove(folderDef);
 
@@ -546,7 +546,7 @@ public partial class DistributionListControl : UserControl
         else
         {
             // Nest inside target folder
-            var (targetDef, _) = FindFolderDefinition(targetFolderNode.Name);
+            var (targetDef, _) = FindFolderDefinition(targetFolderNode);
             if (targetDef is not null)
             {
                 targetDef.Children ??= [];
@@ -710,10 +710,70 @@ public partial class DistributionListControl : UserControl
     }
 
     /// <summary>
-    /// Finds the FolderDefinition matching a given ExplorerNode folder by name,
-    /// searching the entire tree. Returns the definition and its parent list.
+    /// Builds the path of folder names from root to the given node by searching the tree.
+    /// Returns null if the node is not found.
+    /// </summary>
+    private List<string>? GetNodePath(ExplorerNode target)
+    {
+        var path = new List<string>();
+        if (FindNodePath(target, _rootNodes, path))
+            return path;
+        return null;
+    }
+
+    private static bool FindNodePath(ExplorerNode target, ObservableCollection<ExplorerNode> nodes, List<string> path)
+    {
+        foreach (var node in nodes)
+        {
+            if (node == target)
+            {
+                path.Add(node.Name);
+                return true;
+            }
+            if (node.IsFolder)
+            {
+                path.Add(node.Name);
+                if (FindNodePath(target, node.Children, path))
+                    return true;
+                path.RemoveAt(path.Count - 1);
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Finds the FolderDefinition matching a given ExplorerNode by its full path in the tree.
+    /// Falls back to name-only search if path is null. Returns the definition and its parent list.
     /// </summary>
     private (FolderDefinition? folder, List<FolderDefinition> parentList) FindFolderDefinition(
+        ExplorerNode node)
+    {
+        var path = GetNodePath(node);
+        if (path is not null)
+            return FindFolderByNodePath(path);
+        // Fallback: name-only search (for cases where node isn't in tree yet)
+        return FindFolderDefinitionByName(node.Name);
+    }
+
+    private (FolderDefinition? folder, List<FolderDefinition> parentList) FindFolderByNodePath(
+        List<string> path)
+    {
+        var currentList = _folders;
+        for (var i = 0; i < path.Count; i++)
+        {
+            var name = path[i];
+            var match = currentList.FirstOrDefault(f =>
+                string.Equals(f.Name, name, StringComparison.OrdinalIgnoreCase));
+            if (match is null)
+                return (null, currentList);
+            if (i == path.Count - 1)
+                return (match, currentList);
+            currentList = match.Children ?? [];
+        }
+        return (null, currentList);
+    }
+
+    private (FolderDefinition? folder, List<FolderDefinition> parentList) FindFolderDefinitionByName(
         string folderName, List<FolderDefinition>? folders = null)
     {
         folders ??= _folders;
@@ -724,7 +784,7 @@ public partial class DistributionListControl : UserControl
 
             if (f.Children is not null)
             {
-                var found = FindFolderDefinition(folderName, f.Children);
+                var found = FindFolderDefinitionByName(folderName, f.Children);
                 if (found.folder is not null) return found;
             }
         }
@@ -777,7 +837,7 @@ public partial class DistributionListControl : UserControl
     {
         if (DistTree.SelectedItem is not ExplorerNode { IsFolder: true } node) return;
 
-        var (folder, parentList) = FindFolderDefinition(node.Name);
+        var (folder, parentList) = FindFolderDefinition(node);
         if (folder is not null)
         {
             parentList.Remove(folder);
@@ -847,7 +907,7 @@ public partial class DistributionListControl : UserControl
             List<FolderDefinition> targetList;
             if (_newFolderParent is not null)
             {
-                var (parentDef, _) = FindFolderDefinition(_newFolderParent.Name);
+                var (parentDef, _) = FindFolderDefinition(_newFolderParent);
                 if (parentDef is null) return;
                 parentDef.Children ??= [];
                 targetList = parentDef.Children;
@@ -865,7 +925,7 @@ public partial class DistributionListControl : UserControl
         }
         else if (_renamingNode is not null)
         {
-            var (folder, _) = FindFolderDefinition(_renamingNode.Name);
+            var (folder, _) = FindFolderDefinition(_renamingNode);
             if (folder is not null)
                 folder.Name = newName;
         }


### PR DESCRIPTION
## Summary
   - **Fix #27**: Folder "Move to Folder" context menu targeted the wrong folder when duplicate folder names existed. Rewrote folder lookup to use object identity instead of name
   matching. Also fixed submenu click events bubbling to the parent folder's handler.
   - **Fix #28**: Scrollbar in distribution list was too narrow (6px) and clicking near it triggered drag-drop logic instead of scrolling. Widened to 14px, added content padding, and       
   added ScrollBar ancestor guards in pointer handlers.

   ## Changes
   - `DistributionListControl.axaml.cs` — identity-based folder resolution for move targets, submenu event guard, ScrollBar hit-test guards in `OnTreePointerPressed`/`OnTreePointerMoved`   
   - `DistributionListControl.axaml` — right margin on tree item content grid
   - `App.axaml` — ScrollBar width 6 → 14px