### PR TITLE
Expand/Collapse All for distribution list folders

### DIFF
--- a/UI/Controls/DistributionListControl.axaml
+++ b/UI/Controls/DistributionListControl.axaml
@@ -24,6 +24,13 @@
                                FontSize="10"
                                Foreground="{StaticResource TextMuted}"
                                VerticalAlignment="Center" />
+                    <!-- Expand/Collapse All buttons -->
+                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Margin="0 0 6 0">
+                        <Button Classes="FilterPill" Content="⊞" ToolTip.Tip="Expand All"
+                                Click="ExpandAll_Click" Margin="2" Padding="4 2" FontSize="10" />
+                        <Button Classes="FilterPill" Content="⊟" ToolTip.Tip="Collapse All"
+                                Click="CollapseAll_Click" Margin="2" Padding="4 2" FontSize="10" />
+                    </StackPanel>
                 </DockPanel>
                 <TextBox x:Name="SearchBox"
                          Watermark="Search…"
@@ -148,6 +155,9 @@
                     <Separator />
                     <MenuItem Header="Rename Folder" x:Name="RenameFolderItem" Click="RenameFolder_Click" />
                     <MenuItem Header="Delete Folder" x:Name="DeleteFolderItem" Click="DeleteFolder_Click" />
+                    <Separator x:Name="FolderExpandSeparator" />
+                    <MenuItem Header="Expand All in Folder" x:Name="ExpandFolderItem" Click="ExpandFolderAll_Click" />
+                    <MenuItem Header="Collapse All in Folder" x:Name="CollapseFolderItem" Click="CollapseFolderAll_Click" />
                 </ContextMenu>
             </TreeView.ContextMenu>
         </TreeView>

--- a/UI/Controls/DistributionListControl.axaml.cs
+++ b/UI/Controls/DistributionListControl.axaml.cs
@@ -634,8 +634,51 @@ public partial class DistributionListControl : UserControl
         RemoveFromFolderItem.IsVisible = hasDistSelection && anyInFolder;
 
         // Folder-specific items
-        RenameFolderItem.IsVisible = selected is { IsFolder: true };
-        DeleteFolderItem.IsVisible = selected is { IsFolder: true };
+        bool isFolder = selected is { IsFolder: true };
+        RenameFolderItem.IsVisible = isFolder;
+        DeleteFolderItem.IsVisible = isFolder;
+        FolderExpandSeparator.IsVisible = isFolder;
+        ExpandFolderItem.IsVisible = isFolder;
+        CollapseFolderItem.IsVisible = isFolder;
+    }
+
+    private static void SetExpandedRecursive(IEnumerable<ExplorerNode> nodes, bool expanded)
+    {
+        foreach (var node in nodes)
+        {
+            if (!node.IsFolder) continue;
+            node.IsExpanded = expanded;
+            if (node.Children.Count > 0)
+                SetExpandedRecursive(node.Children, expanded);
+        }
+    }
+
+    private void ExpandAll_Click(object? sender, RoutedEventArgs e)
+    {
+        SetExpandedRecursive(_rootNodes, true);
+    }
+
+    private void CollapseAll_Click(object? sender, RoutedEventArgs e)
+    {
+        SetExpandedRecursive(_rootNodes, false);
+    }
+
+    private void ExpandFolderAll_Click(object? sender, RoutedEventArgs e)
+    {
+        if (DistTree.SelectedItem is ExplorerNode { IsFolder: true } folder)
+        {
+            folder.IsExpanded = true;
+            SetExpandedRecursive(folder.Children, true);
+        }
+    }
+
+    private void CollapseFolderAll_Click(object? sender, RoutedEventArgs e)
+    {
+        if (DistTree.SelectedItem is ExplorerNode { IsFolder: true } folder)
+        {
+            folder.IsExpanded = false;
+            SetExpandedRecursive(folder.Children, false);
+        }
     }
 
     private List<ExplorerNode> GetSelectedDistributionNodes()

--- a/UI/Controls/DistributionListControl.axaml.cs
+++ b/UI/Controls/DistributionListControl.axaml.cs
@@ -58,6 +58,12 @@ public partial class DistributionListControl : UserControl
     public (TriState ProcList, TriState Rolls, TriState Items, TriState Junk, TriState Procedural, TriState Invalid) ContentFilters
         => (_procListFilter, _rollsFilter, _itemsFilter, _junkFilter, _proceduralFilter, _invalidFilter);
 
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        SaveFolders();
+    }
+
     public DistributionListControl()
     {
         InitializeComponent();
@@ -656,11 +662,13 @@ public partial class DistributionListControl : UserControl
     private void ExpandAll_Click(object? sender, RoutedEventArgs e)
     {
         SetExpandedRecursive(_rootNodes, true);
+        SaveFolders();
     }
 
     private void CollapseAll_Click(object? sender, RoutedEventArgs e)
     {
         SetExpandedRecursive(_rootNodes, false);
+        SaveFolders();
     }
 
     private void ExpandFolderAll_Click(object? sender, RoutedEventArgs e)
@@ -669,6 +677,7 @@ public partial class DistributionListControl : UserControl
         {
             folder.IsExpanded = true;
             SetExpandedRecursive(folder.Children, true);
+            SaveFolders();
         }
     }
 
@@ -678,6 +687,7 @@ public partial class DistributionListControl : UserControl
         {
             folder.IsExpanded = false;
             SetExpandedRecursive(folder.Children, false);
+            SaveFolders();
         }
     }
 

--- a/UI/Controls/DistributionListControl.axaml.cs
+++ b/UI/Controls/DistributionListControl.axaml.cs
@@ -61,7 +61,7 @@ public partial class DistributionListControl : UserControl
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
-        SaveFolders();
+        SaveExpansionState();
     }
 
     public DistributionListControl()
@@ -662,13 +662,13 @@ public partial class DistributionListControl : UserControl
     private void ExpandAll_Click(object? sender, RoutedEventArgs e)
     {
         SetExpandedRecursive(_rootNodes, true);
-        SaveFolders();
+        SaveExpansionState();
     }
 
     private void CollapseAll_Click(object? sender, RoutedEventArgs e)
     {
         SetExpandedRecursive(_rootNodes, false);
-        SaveFolders();
+        SaveExpansionState();
     }
 
     private void ExpandFolderAll_Click(object? sender, RoutedEventArgs e)
@@ -677,7 +677,7 @@ public partial class DistributionListControl : UserControl
         {
             folder.IsExpanded = true;
             SetExpandedRecursive(folder.Children, true);
-            SaveFolders();
+            SaveExpansionState();
         }
     }
 
@@ -687,7 +687,7 @@ public partial class DistributionListControl : UserControl
         {
             folder.IsExpanded = false;
             SetExpandedRecursive(folder.Children, false);
-            SaveFolders();
+            SaveExpansionState();
         }
     }
 
@@ -1029,6 +1029,17 @@ public partial class DistributionListControl : UserControl
         // Sync expansion state from current tree nodes
         SyncExpansionState(_rootNodes, _folders);
         FolderSettings.Save(DeepCopyFolders(_folders));
+    }
+
+    /// <summary>
+    /// Lightweight save that only syncs expansion state to the existing folder
+    /// definitions and writes them directly — no deep copy needed since the
+    /// folder structure itself hasn't changed.
+    /// </summary>
+    private void SaveExpansionState()
+    {
+        SyncExpansionState(_rootNodes, _folders);
+        FolderSettings.Save(_folders);
     }
 
     private static void SyncExpansionState(


### PR DESCRIPTION
## Summary
- Add  global Expand All (⊞) / Collapse All (⊟) buttons in the distribution list header                                                                                                       - Add per-folder "Expand All in Folder" / "Collapse All in Folder" context menu items (visible only on folder nodes)                                                                         - Fix expansion state not persisting — `OnDetachedFromVisualTree` now saves state on window close                                                                                            - Add lightweight `SaveExpansionState()` that syncs only `IsExpanded` booleans without deep-copying the entire folder tree, used for expansion-only saves                                                                                                                                                                                                                               
  Closes #39, closes #40