### PR TITLE
Fix #41: Add Item button for empty Items/Junk lists

### DIFF
--- a/UI/Controls/ContainerControl.axaml
+++ b/UI/Controls/ContainerControl.axaml
@@ -119,7 +119,13 @@
                     <ScrollViewer Grid.Row="2"
                                   VerticalScrollBarVisibility="Visible"
                                   MaxHeight="260">
-                        <StackPanel x:Name="ItemRowsPanel" />
+                        <StackPanel>
+                            <StackPanel x:Name="ItemRowsPanel" />
+                            <Button Content="+ Add Item" Click="AddItem_Click"
+                                    FontSize="11" Padding="6 3" Margin="4 4"
+                                    HorizontalAlignment="Left" Background="Transparent"
+                                    BorderThickness="0" Foreground="{StaticResource Accent}" />
+                        </StackPanel>
                     </ScrollViewer>
                 </Grid>
 
@@ -159,7 +165,13 @@
                     <ScrollViewer Grid.Row="2"
                                   VerticalScrollBarVisibility="Visible"
                                   MaxHeight="260">
-                        <StackPanel x:Name="JunkRowsPanel" />
+                        <StackPanel>
+                            <StackPanel x:Name="JunkRowsPanel" />
+                            <Button Content="+ Add Item" Click="AddJunkItem_Click"
+                                    FontSize="11" Padding="6 3" Margin="4 4"
+                                    HorizontalAlignment="Left" Background="Transparent"
+                                    BorderThickness="0" Foreground="{StaticResource Accent}" />
+                        </StackPanel>
                     </ScrollViewer>
                 </Grid>
 

--- a/UI/Controls/ContainerControl.axaml.cs
+++ b/UI/Controls/ContainerControl.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -252,5 +253,31 @@ public partial class ContainerControl : UserControl
             $"{_model.Name}.DontSpawnAmmo: {old}\u2192{newVal}",
             v => { _model.DontSpawnAmmo = v; DontSpawnAmmoCheck.IsChecked = v; _model.IsDirty = true; },
             old, newVal));
+    }
+
+    private void AddItem_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_model is null || _undoRedo is null) return;
+        var items = _model.ItemChances;
+        var newItem = new Item("NewItem", 1);
+        var index = items.Count;
+        var context = $"{_model.Name}.items";
+        _undoRedo.Push(new ListInsertAction<Item>(
+            $"{context}: add '{newItem.Name}'",
+            items, index, newItem,
+            () => { ItemRowHelper.Populate(ItemRowsPanel, items, _undoRedo, context, _model); _model.IsDirty = true; }));
+    }
+
+    private void AddJunkItem_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_model is null || _undoRedo is null) return;
+        var items = _model.JunkChances;
+        var newItem = new Item("NewItem", 1);
+        var index = items.Count;
+        var context = $"{_model.Name}.junk";
+        _undoRedo.Push(new ListInsertAction<Item>(
+            $"{context}: add '{newItem.Name}'",
+            items, index, newItem,
+            () => { ItemRowHelper.Populate(JunkRowsPanel, items, _undoRedo, context, _model); _model.IsDirty = true; }));
     }
 }

--- a/UI/Controls/DistributionDetailControl.axaml.cs
+++ b/UI/Controls/DistributionDetailControl.axaml.cs
@@ -93,7 +93,7 @@ public partial class DistributionDetailControl : UserControl
 
             // Show distribution-level items (common for procedural distributions which have
             // items/junk directly on the distribution rather than in named sub-containers).
-            bool hasDirectItems = d.ItemChances.Count > 0 || d.JunkChances.Count > 0;
+            bool hasDirectItems = d.ItemChances.Count > 0 || d.JunkChances.Count > 0 || _showEmpty;
             DirectItemsPanel.IsVisible = hasDirectItems;
             HeaderDirectItems.IsVisible = hasDirectItems;
             if (hasDirectItems)
@@ -102,8 +102,8 @@ public partial class DistributionDetailControl : UserControl
                 DirectCountBadge.Text = $"\u229e {d.ItemChances.Count}";
                 HeaderDirectItemCount.Text = d.ItemChances.Count.ToString();
                 DistItemsControl.Load(d.ItemChances, undoRedo, $"{d.Name}.items", d);
-                JunkTab.IsVisible = d.JunkChances.Count > 0;
-                if (d.JunkChances.Count > 0)
+                JunkTab.IsVisible = d.JunkChances.Count > 0 || _showEmpty;
+                if (d.JunkChances.Count > 0 || _showEmpty)
                     DistJunkControl.Load(d.JunkChances, undoRedo, $"{d.Name}.junk", d);
             }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                
- Add "+ Add Item" buttons to container Items and Junk panels, allowing users to add the first item to empty lists                                                                           - Wire `_showEmpty` toggle into distribution-level DirectItemsPanel and JunkTab visibility, so "Show Empty" reveals these panels even when they have no entries                              - Both buttons support full undo/redo via `ListInsertAction<Item>`                                                                                                                                                                                                                                                                                                                      
